### PR TITLE
Update discrete_act.py to match changes to rlgym

### DIFF
--- a/src/action/discrete_act.py
+++ b/src/action/discrete_act.py
@@ -15,9 +15,9 @@ class DiscreteAction:
         raise NotImplementedError("We don't implement get_action_space to remove the gym dependency")
 
     def parse_actions(self, actions: np.ndarray, state: GameState) -> np.ndarray:
-        actions = actions.reshape((-1, 8))
+        actions = actions.reshape((-1, 8)).astype(dtype=np.float32)
 
-        # map all ternary actions from {0, 1, 2} to {-1, 0, 1}.
+        # map all binned actions from {0, 1, 2 .. n_bins - 1} to {-1 .. 1}.
         actions[..., :5] = actions[..., :5] / (self._n_bins // 2) - 1
 
         return actions


### PR DESCRIPTION
This is the same code from the latest change to rlgym, to work with bins>3.